### PR TITLE
Enable fall-through

### DIFF
--- a/lib/gameLoop.ts
+++ b/lib/gameLoop.ts
@@ -377,7 +377,7 @@ const handleExit =
             )(gameState)
           } else return { ...gameState, message: `${capitalize(toThe(exit.note.door))} is locked.` }
         }
-        break
+      // eslint-disable-next-line no-fallthrough
       default:
         return compose(
           addStatusToDoor(door, "open"),


### PR DESCRIPTION
This fixes a bug that breaks the game whenever the user tries to go
through a double door that has no associated 'keyhole' note.

It stemmed from a bad linting fix. The code was designed to fall-
through to the default behavior of simply moving through the door,
but the bad linting-fix added a 'break' statement.

Fixed by allowing the fall-through and adding a linting disable line
at that point.
